### PR TITLE
Only check for rights file when checking rights file.

### DIFF
--- a/flint-epub/src/main/java/au/gov/nla/flint/epub/checks/SpecificDrmChecks.java
+++ b/flint-epub/src/main/java/au/gov/nla/flint/epub/checks/SpecificDrmChecks.java
@@ -57,18 +57,12 @@ public class SpecificDrmChecks extends TimedTask {
         boolean ret = false;
 
         final String RIGHTSFILE = "META-INF/rights.xml";//http://www.idpf.org/epub/30/spec/epub30-ocf.html#sec-container-metainf-rights.xml
-        final String ENCFILE = "META-INF/encryption.xml";//http://www.idpf.org/epub/30/spec/epub30-ocf.html#sec-container-metainf-encryption.xml
 
         ZipFile zip;
         try {
             zip = new ZipFile(pEPUB);
 
             ZipEntry entry = zip.getEntry(RIGHTSFILE);
-            if(null!=entry) {
-                ret = true;
-            }
-
-            entry = zip.getEntry(ENCFILE);
             if(null!=entry) {
                 ret = true;
             }
@@ -83,7 +77,6 @@ public class SpecificDrmChecks extends TimedTask {
             e.printStackTrace();
         }
 
-        //System.out.println("Rights and/or encryption file: "+ret);
         return ret;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,12 @@
                 <artifactId>xz</artifactId>
                 <version>${xz.version}</version>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/net.sf.saxon/Saxon-HE -->
+            <dependency>
+                <groupId>net.sf.saxon</groupId>
+                <artifactId>Saxon-HE</artifactId>
+                <version>9.8.0-8</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>


### PR DESCRIPTION
I don't know why there is two checks checking for DRM. However, this one erronously checks for both a rights and encryption file. However an encryption file is not by default an implication of DRM, so let's strip it and do what the method says it's doing.